### PR TITLE
Automatically load .env file

### DIFF
--- a/backend/manage.py
+++ b/backend/manage.py
@@ -3,9 +3,14 @@
 import os
 import sys
 
+from dotenv import load_dotenv
+
 
 def main():
     """Run administrative tasks."""
+    # Initialize environment variables from the `.env` file
+    load_dotenv()
+
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'backend.settings')
     try:
         from django.core.management import execute_from_command_line

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,6 +3,7 @@ Django==5.0.4
 django-cors-headers==4.3.1
 djangorestframework==3.15.1
 djangorestframework-simplejwt==5.3.1
+python-dotenv==1.0.1
 mysqlclient==2.2.4
 PyJWT==2.8.0
 ruff==0.4.3


### PR DESCRIPTION
Currently, VS Code does this for its own terminals, but I've had issues with that before. Additionally, other terminals (e.g. a standalone one) will not have the environment variables, and the backend won't run with it.

This PR adds a library called dotenv, which loads these env vars at runtime, so it works for any terminal and doesn't rely on VS Code